### PR TITLE
feat: Add service and job for refreshing materialized views concurrently

### DIFF
--- a/mat_views/.rubocop.yml
+++ b/mat_views/.rubocop.yml
@@ -12,7 +12,7 @@ AllCops:
 Metrics/MethodLength:
   Max: 20
 RSpec/MultipleExpectations:
-  Max: 5
+  Max: 10
 RSpec/ExampleLength:
   Max: 15
 Layout/LineLength:

--- a/mat_views/app/jobs/mat_views/refresh_view_job.rb
+++ b/mat_views/app/jobs/mat_views/refresh_view_job.rb
@@ -36,10 +36,17 @@ module MatViews
 
     def execute(definition, row_count_strategy:)
       started  = monotime
-      response = MatViews::Services::RegularRefresh
-                 .new(definition, row_count_strategy: row_count_strategy)
-                 .run
+      response = service(definition).new(definition, row_count_strategy: row_count_strategy).run
       [response, elapsed_ms(started)]
+    end
+
+    def service(definition)
+      case definition.refresh_strategy
+      when 'concurrent'
+        MatViews::Services::ConcurrentRefresh
+      else
+        MatViews::Services::RegularRefresh
+      end
     end
 
     def start_run(definition)

--- a/mat_views/lib/mat_views.rb
+++ b/mat_views/lib/mat_views.rb
@@ -8,6 +8,7 @@ require 'mat_views/service_response'
 require 'mat_views/services/base_service'
 require 'mat_views/services/create_view'
 require 'mat_views/services/regular_refresh'
+require 'mat_views/services/concurrent_refresh'
 
 # MatViews is a Rails engine that provides support for materialized views.
 #

--- a/mat_views/lib/mat_views/services/concurrent_refresh.rb
+++ b/mat_views/lib/mat_views/services/concurrent_refresh.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+module MatViews
+  module Services
+    # ConcurrentRefresh performs:
+    #   REFRESH MATERIALIZED VIEW CONCURRENTLY <schema>.<rel>
+    # It keeps the view readable during refresh, but requires a UNIQUE index.
+    class ConcurrentRefresh < BaseService
+      attr_reader :row_count_strategy
+
+      # row_count_strategy: :estimated | :exact | nil | other
+      def initialize(definition, row_count_strategy: :estimated)
+        super(definition)
+        @row_count_strategy = row_count_strategy
+      end
+
+      def run
+        prep = prepare!
+        return prep if prep
+
+        sql = "REFRESH MATERIALIZED VIEW CONCURRENTLY #{qualified_rel}"
+
+        conn.execute(sql)
+
+        payload = { view: "#{schema}.#{rel}" }
+        payload[:rows_count] = fetch_rows_count if row_count_strategy.present?
+
+        ok(:updated,
+           payload: payload,
+           meta: { sql: sql, row_count_strategy: row_count_strategy, concurrent: true })
+      rescue PG::ObjectInUse => e
+        # Common lock/contention error during concurrent refreshes.
+        error_response(e,
+                       meta: { sql: sql, row_count_strategy: row_count_strategy, concurrent: true },
+                       payload: { view: "#{schema}.#{rel}" })
+      rescue StandardError => e
+        error_response(e,
+                       meta: { sql: sql, backtrace: Array(e.backtrace), row_count_strategy: row_count_strategy, concurrent: true },
+                       payload: { view: "#{schema}.#{rel}" })
+      end
+
+      # ────────────────────────────────────────────────────────────────
+      # internal
+      # ────────────────────────────────────────────────────────────────
+
+      def prepare!
+        return err("Invalid view name format: #{definition.name.inspect}") unless valid_name?
+        return err("Materialized view #{schema}.#{rel} does not exist") unless view_exists?
+        return err("Materialized view #{schema}.#{rel} must have a unique index for concurrent refresh") unless unique_index_exists?
+
+        nil
+      end
+
+      # ────────────────────────────────────────────────────────────────
+      # helpers: validation / schema / pg introspection
+      # (mirrors RegularRefresh for consistency)
+      # ────────────────────────────────────────────────────────────────
+
+      def valid_name?
+        /\A[a-zA-Z_][a-zA-Z0-9_]*\z/.match?(definition.name.to_s)
+      end
+
+      def resolve_schema_token(token)
+        cleaned = token.delete_prefix('"').delete_suffix('"')
+        return current_user if cleaned == '$user'
+
+        cleaned
+      end
+
+      # Any UNIQUE index on the matview satisfies the CONCURRENTLY requirement.
+      def unique_index_exists?
+        conn.select_value(<<~SQL).to_i.positive?
+          SELECT COUNT(*)
+          FROM pg_index i
+          JOIN pg_class c ON c.oid = i.indrelid
+          JOIN pg_namespace n ON n.oid = c.relnamespace
+          WHERE n.nspname = #{conn.quote(schema)}
+            AND c.relname = #{conn.quote(rel)}
+            AND i.indisunique = TRUE
+        SQL
+      end
+
+      # ────────────────────────────────────────────────────────────────
+      # rows counting (same as RegularRefresh)
+      # ────────────────────────────────────────────────────────────────
+
+      def fetch_rows_count
+        case row_count_strategy
+        when :estimated then estimated_rows_count
+        when :exact     then exact_rows_count
+        end
+      end
+
+      # Fast/approx via pg_class.reltuples.
+      def estimated_rows_count
+        conn.select_value(<<~SQL).to_i
+          SELECT COALESCE(c.reltuples::bigint, 0)
+          FROM pg_class c
+          JOIN pg_namespace n ON n.oid = c.relnamespace
+          WHERE c.relkind IN ('m','r','p')
+            AND n.nspname = #{conn.quote(schema)}
+            AND c.relname = #{conn.quote(rel)}
+          LIMIT 1
+        SQL
+      end
+
+      # Accurate but heavier.
+      def exact_rows_count
+        conn.select_value("SELECT COUNT(*) FROM #{qualified_rel}").to_i
+      end
+    end
+  end
+end

--- a/mat_views/spec/jobs/mat_views/refresh_view_job_spec.rb
+++ b/mat_views/spec/jobs/mat_views/refresh_view_job_spec.rb
@@ -11,12 +11,22 @@ RSpec.describe MatViews::RefreshViewJob, type: :job do
     end
   end
 
-  let!(:definition) do
+  let!(:definition_regular) do
     create(
       :mat_view_definition,
       name: 'mv_refresh_runner_job_spec',
       sql: 'SELECT 1 AS id',
       refresh_strategy: :regular
+    )
+  end
+
+  let!(:definition_concurrent) do
+    create(
+      :mat_view_definition,
+      name: 'mv_concurrent_refresh_runner_job_spec',
+      sql: 'SELECT 1 AS id',
+      refresh_strategy: :concurrent,
+      unique_index_columns: %w[id]
     )
   end
 
@@ -33,165 +43,167 @@ RSpec.describe MatViews::RefreshViewJob, type: :job do
     )
   end
 
-  describe 'queueing' do
-    it 'enqueues on the configured queue (hash arg)' do
-      expect do
-        described_class.perform_later(definition.id, row_count_strategy: :exact)
-      end.to have_enqueued_job(described_class)
-        .on_queue('mat_views_test')
-        .with(definition.id, row_count_strategy: :exact)
+  shared_examples 'a refresh job' do
+    describe 'queueing' do
+      it 'enqueues on the configured queue (hash arg)' do
+        expect do
+          described_class.perform_later(definition.id, row_count_strategy: :exact)
+        end.to have_enqueued_job(described_class)
+          .on_queue('mat_views_test')
+          .with(definition.id, row_count_strategy: :exact)
+      end
+
+      it 'enqueues on the configured queue (bare symbol arg)' do
+        expect do
+          described_class.perform_later(definition.id, :estimated)
+        end.to have_enqueued_job(described_class)
+          .on_queue('mat_views_test')
+          .with(definition.id, :estimated)
+      end
     end
 
-    it 'enqueues on the configured queue (bare symbol arg)' do
-      expect do
-        described_class.perform_later(definition.id, :estimated)
-      end.to have_enqueued_job(described_class)
-        .on_queue('mat_views_test')
-        .with(definition.id, :estimated)
+    describe '#perform' do
+      context 'when the service returns success' do
+        it 'returns the response hash' do
+          resp = service_response_double(status: :updated, payload: { view: 'public.mv' })
+          svc  = instance_spy(svc_class, run: resp)
+          allow(svc_class).to receive(:new).with(definition, row_count_strategy: :exact).and_return(svc)
+
+          result = perform_now_and_return(definition.id, row_count_strategy: :exact)
+          expect(result).to eq(resp.to_h)
+        end
+
+        it 'records a successful refresh run with core fields set' do
+          resp = service_response_double(status: :updated, payload: { view: 'public.mv' })
+          svc  = instance_spy(svc_class, run: resp)
+          allow(svc_class).to receive(:new).with(definition, row_count_strategy: :estimated).and_return(svc)
+
+          perform_now_and_return(definition.id)
+
+          run    = MatViews::MatViewRefreshRun.order(created_at: :desc).first
+          fields = run.attributes.slice('mat_view_definition_id', 'status', 'error')
+          expect(fields).to eq(
+            'mat_view_definition_id' => definition.id,
+            'status' => 'success',
+            'error' => nil
+          )
+        end
+
+        it 'persists timing and meta' do
+          resp = service_response_double(status: :updated, payload: { view: 'public.mv', rows_count: 1 })
+          svc  = instance_spy(svc_class, run: resp)
+          allow(svc_class).to receive(:new).with(definition, row_count_strategy: :estimated).and_return(svc)
+
+          perform_now_and_return(definition.id)
+
+          run = MatViews::MatViewRefreshRun.order(created_at: :desc).first
+          expect(run.meta).to include('view' => 'public.mv', 'rows_count' => 1)
+          expect([run.started_at.present?, run.finished_at.present?, run.duration_ms.is_a?(Integer)]).to eq([true, true, true])
+        end
+      end
+
+      context 'when the service returns error (no raise)' do
+        it 'returns the response hash and records failed run' do
+          resp = service_response_double(status: :error, error: 'View missing')
+          svc  = instance_spy(svc_class, run: resp)
+          allow(svc_class).to receive(:new).with(definition, row_count_strategy: :estimated).and_return(svc)
+
+          result = perform_now_and_return(definition.id)
+          expect(result).to eq(resp.to_h)
+
+          run    = MatViews::MatViewRefreshRun.order(created_at: :desc).first
+          fields = run.attributes.slice('status', 'error')
+          expect(fields['status']).to eq('failed')
+          expect(fields['error']).to match(/View missing/)
+        end
+      end
+
+      context 'when the service raises' do
+        it 're-raises and marks the run failed' do
+          svc = instance_spy(svc_class)
+          allow(svc_class).to receive(:new).with(definition, row_count_strategy: :estimated).and_return(svc)
+          allow(svc).to receive(:run).and_raise(StandardError, 'kaboom')
+
+          expect do
+            perform_now_and_return(definition.id)
+          end.to raise_error(Minitest::UnexpectedError, /kaboom/)
+
+          run    = MatViews::MatViewRefreshRun.order(created_at: :desc).first
+          fields = run.attributes.slice('status', 'error')
+          expect(fields['status']).to eq('failed')
+          expect(fields['error']).to match(/StandardError: kaboom/)
+        end
+      end
+
+      context 'when run fails to save' do
+        it 'raises and does not attempt to update the run' do
+          resp = service_response_double(status: :updated, payload: { view: 'public.mv' })
+          svc  = instance_spy(svc_class, run: resp)
+          allow(svc_class).to receive(:new).with(definition, row_count_strategy: :estimated).and_return(svc)
+
+          allow(MatViews::MatViewRefreshRun).to receive(:create!).and_raise(ActiveRecord::RecordInvalid)
+
+          expect do
+            perform_now_and_return(definition.id)
+          end.to raise_error(Minitest::UnexpectedError)
+
+          expect(MatViews::MatViewRefreshRun).to have_received(:create!).once
+        end
+      end
+
+      describe 'strategy normalization' do
+        it 'accepts a bare symbol' do
+          resp = service_response_double(status: :updated)
+          svc  = instance_spy(svc_class, run: resp)
+          allow(svc_class).to receive(:new).with(definition, row_count_strategy: :exact).and_return(svc)
+          perform_now_and_return(definition.id, :exact)
+
+          expect(svc_class).to have_received(:new).with(definition, row_count_strategy: :exact).once
+          expect(svc).to have_received(:run).once
+        end
+
+        it 'accepts a string' do
+          resp = service_response_double(status: :updated)
+          svc  = instance_spy(svc_class, run: resp)
+          allow(svc_class).to receive(:new).with(definition, row_count_strategy: :estimated).and_return(svc)
+          perform_now_and_return(definition.id, 'estimated')
+
+          expect(svc_class).to have_received(:new).with(definition, row_count_strategy: :estimated).once
+
+          expect(svc).to have_received(:run).once
+        end
+
+        it 'accepts a hash with :row_count_strategy / :strategy keys' do
+          resp = service_response_double(status: :updated)
+          svc1 = instance_spy(svc_class, run: resp)
+          allow(svc_class).to receive(:new).with(definition, row_count_strategy: :exact).and_return(svc1)
+          perform_now_and_return(definition.id, row_count_strategy: :exact)
+
+          svc2 = instance_spy(svc_class, run: resp)
+          allow(svc_class).to receive(:new).with(definition, row_count_strategy: :exact).and_return(svc2)
+          perform_now_and_return(definition.id, strategy: :exact)
+
+          expect(svc_class).to have_received(:new).with(definition, row_count_strategy: :exact).twice
+
+          expect(svc1).to have_received(:run).once
+          expect(svc2).to have_received(:run).once
+        end
+      end
     end
   end
 
-  describe '#perform' do
-    context 'when the service returns success' do
-      it 'returns the response hash' do
-        resp = service_response_double(status: :updated, payload: { view: 'public.mv' })
-        svc  = instance_spy(MatViews::Services::RegularRefresh, run: resp)
-        allow(MatViews::Services::RegularRefresh)
-          .to receive(:new).with(definition, row_count_strategy: :exact).and_return(svc)
+  context 'when the definition uses regular refresh' do
+    let(:definition) { definition_regular }
+    let(:svc_class) { MatViews::Services::RegularRefresh }
 
-        result = perform_now_and_return(definition.id, row_count_strategy: :exact)
-        expect(result).to eq(resp.to_h)
-      end
+    it_behaves_like 'a refresh job'
+  end
 
-      it 'records a successful refresh run with core fields set' do
-        resp = service_response_double(status: :updated, payload: { view: 'public.mv' })
-        svc  = instance_spy(MatViews::Services::RegularRefresh, run: resp)
-        allow(MatViews::Services::RegularRefresh)
-          .to receive(:new).with(definition, row_count_strategy: :estimated).and_return(svc)
+  context 'when the definition uses concurrent refresh' do
+    let(:definition) { definition_concurrent }
+    let(:svc_class) { MatViews::Services::ConcurrentRefresh }
 
-        perform_now_and_return(definition.id)
-
-        run    = MatViews::MatViewRefreshRun.order(created_at: :desc).first
-        fields = run.attributes.slice('mat_view_definition_id', 'status', 'error')
-        expect(fields).to eq(
-          'mat_view_definition_id' => definition.id,
-          'status' => 'success',
-          'error' => nil
-        )
-      end
-
-      it 'persists timing and meta' do
-        resp = service_response_double(status: :updated, payload: { view: 'public.mv', rows_count: 1 })
-        svc  = instance_spy(MatViews::Services::RegularRefresh, run: resp)
-        allow(MatViews::Services::RegularRefresh)
-          .to receive(:new).with(definition, row_count_strategy: :estimated).and_return(svc)
-
-        perform_now_and_return(definition.id)
-
-        run = MatViews::MatViewRefreshRun.order(created_at: :desc).first
-        expect(run.meta).to include('view' => 'public.mv', 'rows_count' => 1)
-        expect([run.started_at.present?, run.finished_at.present?, run.duration_ms.is_a?(Integer)]).to eq([true, true, true])
-      end
-    end
-
-    context 'when the service returns error (no raise)' do
-      it 'returns the response hash and records failed run' do
-        resp = service_response_double(status: :error, error: 'View missing')
-        svc  = instance_spy(MatViews::Services::RegularRefresh, run: resp)
-        allow(MatViews::Services::RegularRefresh)
-          .to receive(:new).with(definition, row_count_strategy: :estimated).and_return(svc)
-
-        result = perform_now_and_return(definition.id)
-        expect(result).to eq(resp.to_h)
-
-        run    = MatViews::MatViewRefreshRun.order(created_at: :desc).first
-        fields = run.attributes.slice('status', 'error')
-        expect(fields['status']).to eq('failed')
-        expect(fields['error']).to match(/View missing/)
-      end
-    end
-
-    context 'when the service raises' do
-      it 're-raises and marks the run failed' do
-        svc = instance_spy(MatViews::Services::RegularRefresh)
-        allow(MatViews::Services::RegularRefresh)
-          .to receive(:new).with(definition, row_count_strategy: :estimated).and_return(svc)
-        allow(svc).to receive(:run).and_raise(StandardError, 'kaboom')
-
-        expect do
-          perform_now_and_return(definition.id)
-        end.to raise_error(Minitest::UnexpectedError, /kaboom/)
-
-        run    = MatViews::MatViewRefreshRun.order(created_at: :desc).first
-        fields = run.attributes.slice('status', 'error')
-        expect(fields['status']).to eq('failed')
-        expect(fields['error']).to match(/StandardError: kaboom/)
-      end
-    end
-
-    context 'when run fails to save' do
-      it 'raises and does not attempt to update the run' do
-        resp = service_response_double(status: :updated, payload: { view: 'public.mv' })
-        svc  = instance_spy(MatViews::Services::RegularRefresh, run: resp)
-        allow(MatViews::Services::RegularRefresh)
-          .to receive(:new).with(definition, row_count_strategy: :estimated).and_return(svc)
-
-        allow(MatViews::MatViewRefreshRun).to receive(:create!).and_raise(ActiveRecord::RecordInvalid)
-
-        expect do
-          perform_now_and_return(definition.id)
-        end.to raise_error(Minitest::UnexpectedError)
-
-        expect(MatViews::MatViewRefreshRun).to have_received(:create!).once
-      end
-    end
-
-    describe 'strategy normalization' do
-      it 'accepts a bare symbol' do
-        resp = service_response_double(status: :updated)
-        svc  = instance_spy(MatViews::Services::RegularRefresh, run: resp)
-        allow(MatViews::Services::RegularRefresh)
-          .to receive(:new).with(definition, row_count_strategy: :exact).and_return(svc)
-        perform_now_and_return(definition.id, :exact)
-
-        expect(MatViews::Services::RegularRefresh).to have_received(:new)
-          .with(definition, row_count_strategy: :exact).once
-
-        expect(svc).to have_received(:run).once
-      end
-
-      it 'accepts a string' do
-        resp = service_response_double(status: :updated)
-        svc  = instance_spy(MatViews::Services::RegularRefresh, run: resp)
-        allow(MatViews::Services::RegularRefresh)
-          .to receive(:new).with(definition, row_count_strategy: :estimated).and_return(svc)
-        perform_now_and_return(definition.id, 'estimated')
-
-        expect(MatViews::Services::RegularRefresh).to have_received(:new)
-          .with(definition, row_count_strategy: :estimated).once
-
-        expect(svc).to have_received(:run).once
-      end
-
-      it 'accepts a hash with :row_count_strategy / :strategy keys' do
-        resp = service_response_double(status: :updated)
-        svc1 = instance_spy(MatViews::Services::RegularRefresh, run: resp)
-        allow(MatViews::Services::RegularRefresh)
-          .to receive(:new).with(definition, row_count_strategy: :exact).and_return(svc1)
-        perform_now_and_return(definition.id, row_count_strategy: :exact)
-
-        svc2 = instance_spy(MatViews::Services::RegularRefresh, run: resp)
-        allow(MatViews::Services::RegularRefresh)
-          .to receive(:new).with(definition, row_count_strategy: :exact).and_return(svc2)
-        perform_now_and_return(definition.id, strategy: :exact)
-
-        expect(MatViews::Services::RegularRefresh).to have_received(:new)
-          .with(definition, row_count_strategy: :exact).twice
-
-        expect(svc1).to have_received(:run).once
-        expect(svc2).to have_received(:run).once
-      end
-    end
+    it_behaves_like 'a refresh job'
   end
 
   # helpers

--- a/mat_views/spec/lib/mat_views/services/concurrent_refresh_spec.rb
+++ b/mat_views/spec/lib/mat_views/services/concurrent_refresh_spec.rb
@@ -1,0 +1,201 @@
+# frozen_string_literal: true
+
+RSpec.describe MatViews::Services::ConcurrentRefresh do
+  let(:conn)     { ActiveRecord::Base.connection }
+  let(:relname)  { 'mv_concurrent_refresh_spec' }
+  let(:qualified) { "public.#{relname}" }
+
+  let(:definition) do
+    build(:mat_view_definition,
+          name: relname,
+          sql: 'SELECT id FROM users',
+          refresh_strategy: :concurrent,
+          unique_index_columns: %w[id])
+  end
+
+  let(:row_count_strategy) { :estimated }
+  let(:runner)             { described_class.new(definition, row_count_strategy:) }
+  let(:execute_service)    { runner.run }
+
+  before do
+    # start from a clean slate
+    conn.execute(%(DROP MATERIALIZED VIEW IF EXISTS public."#{relname}"))
+  end
+
+  def mv_exists?(rel, schema: 'public')
+    conn.select_value(<<~SQL).to_i.positive?
+      SELECT COUNT(*)
+      FROM pg_matviews
+      WHERE schemaname=#{conn.quote(schema)} AND matviewname=#{conn.quote(rel)}
+    SQL
+  end
+
+  def create_mv!(rel, schema: 'public')
+    quoted_table = conn.quote_table_name("#{schema}.#{rel}")
+    conn.execute("CREATE MATERIALIZED VIEW #{quoted_table} AS SELECT id FROM users WITH DATA")
+  end
+
+  def add_unique_index!(rel, schema: 'public', column: 'id')
+    idx_name = %("#{rel}_uniq_#{column}")
+    # Regular (non-concurrent) index is fine for tests; dropping the MV cleans it up.
+    conn.execute(%(CREATE UNIQUE INDEX #{idx_name} ON #{conn.quote_table_name("#{schema}.#{rel}")} (#{conn.quote_column_name(column)})))
+  end
+
+  describe 'validations' do
+    it 'fails when name is invalid format' do
+      definition.name = 'public.mv.bad'
+      res = execute_service
+      expect(res.error?).to be(true)
+      expect(res.error).to match(/Invalid view name format/i)
+      expect(mv_exists?(relname)).to be(false)
+    end
+
+    it 'fails when the view does not exist' do
+      res = execute_service
+      expect(res.error?).to be(true)
+      expect(res.error).to match(/does not exist/i)
+      expect(mv_exists?(relname)).to be(false)
+    end
+  end
+
+  describe 'unique index requirement' do
+    it 'errors when no unique index is present' do
+      create_mv!(relname, schema: 'public')
+      allow(conn).to receive(:schema_search_path).and_return('public')
+
+      res = execute_service
+
+      expect(res.error?).to be(true)
+      expect(res.error).to match(/unique index/i)
+    end
+  end
+
+  describe 'successful refresh' do
+    before do
+      create_mv!(relname, schema: 'public')
+      add_unique_index!(relname, schema: 'public', column: 'id')
+      allow(conn).to receive(:schema_search_path).and_return('public')
+    end
+
+    it 'refreshes concurrently and returns :updated with estimated rows and meta' do
+      res = execute_service
+
+      expect(res.status).to eq(:updated)
+      expect(res.payload[:view]).to eq("public.#{relname}")
+      expect(res.payload[:rows_count]).to be_a(Integer)
+      expect(res.meta[:row_count_strategy]).to eq(:estimated)
+      expect(res.meta[:concurrent]).to be(true)
+      expect(res.meta[:sql]).to eq(%(REFRESH MATERIALIZED VIEW CONCURRENTLY "public"."#{relname}"))
+    end
+
+    describe 'exact row count' do
+      let(:row_count_strategy) { :exact }
+
+      it 'uses COUNT(*) and returns the exact number' do
+        res = execute_service
+        expect(res).to be_success
+        expect(res.payload[:rows_count]).to be_a(Integer)
+        expect(res.meta[:row_count_strategy]).to eq(:exact)
+      end
+    end
+
+    describe 'unknown row_count_strategy symbol' do
+      let(:row_count_strategy) { :bogus }
+
+      it 'includes rows_count: nil when strategy is unrecognized' do
+        res = execute_service
+        expect(res).to be_success
+        expect(res.payload).to include(rows_count: nil)
+        expect(res.meta[:row_count_strategy]).to eq(:bogus)
+      end
+    end
+
+    describe 'no row count requested (nil)' do
+      let(:row_count_strategy) { nil }
+
+      it 'does not include rows_count' do
+        res = execute_service
+        expect(res).to be_success
+        expect(res.payload).not_to have_key(:rows_count)
+        expect(res.meta[:row_count_strategy]).to be_nil
+      end
+    end
+  end
+
+  describe 'schema_search_path resolution' do
+    before do
+      create_mv!(relname, schema: 'public')
+      add_unique_index!(relname, schema: 'public', column: 'id')
+    end
+
+    it 'falls back to public when search_path is empty' do
+      allow(conn).to receive(:schema_search_path).and_return('')
+      res = execute_service
+      expect(res).to be_success
+      expect(res.payload[:view]).to eq("public.#{relname}")
+    end
+
+    it 'ignores non-existent schemas and falls back to public' do
+      allow(conn).to receive(:schema_search_path).and_return('other_schema')
+      res = execute_service
+      expect(res).to be_success
+      expect(res.payload[:view]).to eq("public.#{relname}")
+    end
+
+    it 'handles quoted tokens' do
+      allow(conn).to receive(:schema_search_path).and_return('"public"')
+      res = execute_service
+      expect(res).to be_success
+      expect(res.payload[:view]).to eq("public.#{relname}")
+    end
+
+    it 'handles $user token; uses public when user schema is absent' do
+      allow(conn).to receive(:schema_search_path).and_return('$user,public')
+      res = execute_service
+      expect(res).to be_success
+      expect(res.payload[:view]).to eq("public.#{relname}")
+    end
+  end
+
+  describe 'locking / DB errors' do
+    before do
+      create_mv!(relname, schema: 'public')
+      add_unique_index!(relname, schema: 'public', column: 'id')
+      allow(conn).to receive(:schema_search_path).and_return('public')
+    end
+
+    it 'wraps PG::ObjectInUse into error response with meta.sql and payload.view' do
+      allow(ActiveRecord::Base).to receive(:connection).and_wrap_original do |orig, *args|
+        c = orig.call(*args)
+        allow(c).to receive(:execute)
+          .with(%(REFRESH MATERIALIZED VIEW CONCURRENTLY "public"."#{relname}"))
+          .and_raise(PG::ObjectInUse, 'relation is being used by another process')
+        c
+      end
+
+      res = execute_service
+      expect(res.error?).to be(true)
+      expect(res.error).to match(/ObjectInUse|being used by another process/i)
+      expect(res.payload[:view]).to eq("public.#{relname}")
+      expect(res.meta[:sql]).to eq(%(REFRESH MATERIALIZED VIEW CONCURRENTLY "public"."#{relname}"))
+      expect(res.meta[:concurrent]).to be(true)
+    end
+
+    it 'wraps unexpected DB error with backtrace and meta.sql' do
+      allow(ActiveRecord::Base).to receive(:connection).and_wrap_original do |orig, *args|
+        c = orig.call(*args)
+        allow(c).to receive(:execute)
+          .with(%(REFRESH MATERIALIZED VIEW CONCURRENTLY "public"."#{relname}"))
+          .and_raise(StandardError, 'boom')
+        c
+      end
+
+      res = execute_service
+      expect(res.error?).to be(true)
+      expect(res.error).to match(/StandardError: boom/)
+      expect(res.payload[:view]).to eq("public.#{relname}")
+      expect(res.meta[:sql]).to eq(%(REFRESH MATERIALIZED VIEW CONCURRENTLY "public"."#{relname}"))
+      expect(res.meta[:concurrent]).to be(true)
+    end
+  end
+end


### PR DESCRIPTION
Introduces a new `ConcurrentRefresh` service to perform non-blocking materialised view updates using `REFRESH MATERIALIZED VIEW CONCURRENTLY`.

This allows views to remain readable during the refresh process, which requires the view to have a unique index.

The `RefreshViewJob` now dynamically selects the appropriate refresh service (regular or concurrent) based on a `refresh_strategy` attribute on the view definition.

Adds comprehensive tests for the new concurrent refresh service and refactors the job spec to use shared examples for both refresh strategies.

closes #49 