### PR TITLE
feat: Add service and job for refreshing materialized views using swap

### DIFF
--- a/mat_views/app/jobs/mat_views/refresh_view_job.rb
+++ b/mat_views/app/jobs/mat_views/refresh_view_job.rb
@@ -49,6 +49,8 @@ module MatViews
       case definition.refresh_strategy
       when 'concurrent'
         MatViews::Services::ConcurrentRefresh
+      when 'swap'
+        MatViews::Services::SwapRefresh
       else
         MatViews::Services::RegularRefresh
       end

--- a/mat_views/lib/mat_views.rb
+++ b/mat_views/lib/mat_views.rb
@@ -14,6 +14,7 @@ require 'mat_views/services/base_service'
 require 'mat_views/services/create_view'
 require 'mat_views/services/regular_refresh'
 require 'mat_views/services/concurrent_refresh'
+require 'mat_views/services/swap_refresh'
 
 # MatViews is a Rails engine that provides support for materialized views.
 #

--- a/mat_views/lib/mat_views/services/swap_refresh.rb
+++ b/mat_views/lib/mat_views/services/swap_refresh.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+require 'securerandom'
+
+module MatViews
+  module Services
+    # SwapRefresh rebuilds into a temporary MV and atomically swaps it in.
+    # Steps:
+    # 1) CREATE MATERIALIZED VIEW <tmp> AS <definition.sql> WITH DATA
+    # 2) (txn) RENAME original -> <old>, RENAME tmp -> original, DROP <old>
+    # 3) Recreate declared indexes/privileges as needed
+    class SwapRefresh < BaseService
+      attr_reader :row_count_strategy
+
+      def initialize(definition, row_count_strategy: :estimated)
+        super(definition)
+        @row_count_strategy = row_count_strategy
+      end
+
+      def run
+        prep = prepare!
+        return prep if prep
+
+        create_sql = %(CREATE MATERIALIZED VIEW #{q_tmp} AS #{definition.sql} WITH DATA)
+        steps = [create_sql]
+        conn.execute(create_sql)
+
+        steps.concat(swap_index)
+
+        payload = { view: "#{schema}.#{rel}" }
+        payload[:rows_count] = fetch_rows_count if row_count_strategy.present?
+
+        ok(:updated,
+           payload: payload,
+           meta: { steps: steps, row_count_strategy: row_count_strategy, swap: true })
+      rescue StandardError => e
+        error_response(e,
+                       meta: { steps: steps, backtrace: Array(e.backtrace), row_count_strategy: row_count_strategy, swap: true },
+                       payload: { view: "#{schema}.#{rel}" })
+      end
+
+      # ────────────────────────────────────────────────────────────────
+      # internal
+      # ────────────────────────────────────────────────────────────────
+
+      def prepare!
+        return err("Invalid view name format: #{definition.name.inspect}") unless valid_name?
+        return err("Materialized view #{schema}.#{rel} does not exist") unless view_exists?
+
+        nil
+      end
+
+      def swap_index
+        steps = []
+        conn.transaction do
+          rename_orig_sql = %(ALTER MATERIALIZED VIEW #{qualified_rel} RENAME TO #{conn.quote_column_name(old_rel)})
+          steps << rename_orig_sql
+          conn.execute(rename_orig_sql)
+
+          rename_tmp_sql = %(ALTER MATERIALIZED VIEW #{q_tmp} RENAME TO #{conn.quote_column_name(rel)})
+          steps << rename_tmp_sql
+          conn.execute(rename_tmp_sql)
+
+          drop_old_sql = %(DROP MATERIALIZED VIEW #{q_old})
+          steps << drop_old_sql
+          conn.execute(drop_old_sql)
+
+          recreate_declared_unique_indexes!(schema:, rel:, steps:)
+        end
+        steps
+      end
+
+      def q_tmp
+        @q_tmp ||= conn.quote_table_name("#{schema}.#{tmp_rel}")
+      end
+
+      def q_old
+        @q_old ||= conn.quote_table_name("#{schema}.#{old_rel}")
+      end
+
+      def tmp_rel
+        @tmp_rel ||= "#{rel}__tmp_#{SecureRandom.hex(4)}"
+      end
+
+      def old_rel
+        @old_rel ||= "#{rel}__old_#{SecureRandom.hex(4)}"
+      end
+
+      # Keep consistency with Regular/Concurrent services
+      def valid_name?
+        /\A[a-zA-Z_][a-zA-Z0-9_]*\z/.match?(definition.name.to_s)
+      end
+
+      def resolve_schema_token(token)
+        cleaned = token.delete_prefix('"').delete_suffix('"')
+        return current_user if cleaned == '$user'
+
+        cleaned
+      end
+
+      # Create unique index(es) described by definition.unique_index_columns
+      # Accepts single or multiple columns (array of strings).
+      def recreate_declared_unique_indexes!(schema:, rel:, steps:)
+        cols = Array(definition.unique_index_columns).map(&:to_s).reject(&:empty?)
+        return if cols.empty?
+
+        quoted_cols = cols.map { |c| conn.quote_column_name(c) }.join(', ')
+        idx_name    = conn.quote_column_name("#{rel}_uniq_#{cols.join('_')}")
+        q_rel       = conn.quote_table_name("#{schema}.#{rel}")
+
+        sql = %(CREATE UNIQUE INDEX #{idx_name} ON #{q_rel} (#{quoted_cols}))
+        steps << sql
+        conn.execute(sql)
+      end
+
+      # ────────────────────────────────────────────────────────────────
+      # rows counting (same as your other services)
+      # ────────────────────────────────────────────────────────────────
+
+      def fetch_rows_count
+        case row_count_strategy
+        when :estimated then estimated_rows_count
+        when :exact     then exact_rows_count
+        end
+      end
+
+      def estimated_rows_count
+        conn.select_value(<<~SQL).to_i
+          SELECT COALESCE(c.reltuples::bigint, 0)
+          FROM pg_class c
+          JOIN pg_namespace n ON n.oid = c.relnamespace
+          WHERE c.relkind IN ('m','r','p')
+            AND n.nspname = #{conn.quote(schema)}
+            AND c.relname = #{conn.quote(rel)}
+          LIMIT 1
+        SQL
+      end
+
+      def exact_rows_count
+        conn.select_value("SELECT COUNT(*) FROM #{qualified_rel}").to_i
+      end
+    end
+  end
+end

--- a/mat_views/spec/jobs/mat_views/refresh_view_job_spec.rb
+++ b/mat_views/spec/jobs/mat_views/refresh_view_job_spec.rb
@@ -35,6 +35,16 @@ RSpec.describe MatViews::RefreshViewJob, type: :job do
     )
   end
 
+  let!(:definition_swap) do
+    create(
+      :mat_view_definition,
+      name: 'mv_swap_refresh_runner_job_spec',
+      sql: 'SELECT 1 AS id',
+      refresh_strategy: :swap,
+      unique_index_columns: []
+    )
+  end
+
   def service_response_double(status:, payload: {}, error: nil)
     success = (status != :error)
     instance_double(
@@ -207,6 +217,13 @@ RSpec.describe MatViews::RefreshViewJob, type: :job do
   context 'when the definition uses concurrent refresh' do
     let(:definition) { definition_concurrent }
     let(:svc_class) { MatViews::Services::ConcurrentRefresh }
+
+    it_behaves_like 'a refresh job'
+  end
+
+  context 'when the definition uses swap refresh' do
+    let(:definition) { definition_swap }
+    let(:svc_class) { MatViews::Services::SwapRefresh }
 
     it_behaves_like 'a refresh job'
   end

--- a/mat_views/spec/lib/mat_views/services/swap_refresh_spec.rb
+++ b/mat_views/spec/lib/mat_views/services/swap_refresh_spec.rb
@@ -1,0 +1,203 @@
+# frozen_string_literal: true
+
+RSpec.describe MatViews::Services::SwapRefresh do
+  let(:conn)      { ActiveRecord::Base.connection }
+  let(:relname)   { 'mv_swap_refresh_spec' }
+  let(:qualified) { "public.#{relname}" }
+
+  let(:definition) do
+    build(:mat_view_definition,
+          name: relname,
+          sql: 'SELECT id FROM users',
+          refresh_strategy: :swap,
+          unique_index_columns: [])
+  end
+
+  let(:row_count_strategy) { :estimated }
+  let(:runner)             { described_class.new(definition, row_count_strategy:) }
+  let(:execute_service)    { runner.run }
+
+  before do
+    conn.execute(%(DROP MATERIALIZED VIEW IF EXISTS public."#{relname}"))
+  end
+
+  def mv_exists?(rel, schema: 'public')
+    conn.select_value(<<~SQL).to_i.positive?
+      SELECT COUNT(*)
+      FROM pg_matviews
+      WHERE schemaname=#{conn.quote(schema)} AND matviewname=#{conn.quote(rel)}
+    SQL
+  end
+
+  def create_mv!(rel, schema: 'public')
+    quoted_table = conn.quote_table_name("#{schema}.#{rel}")
+    conn.execute("CREATE MATERIALIZED VIEW #{quoted_table} AS SELECT id FROM users WITH DATA")
+  end
+
+  def unique_index_count(rel, schema: 'public')
+    conn.select_value(<<~SQL).to_i
+      SELECT COUNT(*)
+      FROM pg_index i
+      JOIN pg_class c ON c.oid = i.indrelid
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = #{conn.quote(schema)}
+        AND c.relname = #{conn.quote(rel)}
+        AND i.indisunique = TRUE
+    SQL
+  end
+
+  describe 'validations' do
+    it 'fails when name is invalid format' do
+      definition.name = 'public.mv.bad'
+      res = execute_service
+      expect(res.error?).to be(true)
+      expect(res.error).to match(/Invalid view name format/i)
+      expect(mv_exists?(relname)).to be(false)
+    end
+
+    it 'fails when the view does not exist' do
+      res = execute_service
+      expect(res.error?).to be(true)
+      expect(res.error).to match(/does not exist/i)
+      expect(mv_exists?(relname)).to be(false)
+    end
+  end
+
+  describe 'successful swap' do
+    before do
+      create_mv!(relname, schema: 'public')
+      allow(conn).to receive(:schema_search_path).and_return('public')
+    end
+
+    it 'rebuilds into a temp MV and atomically swaps it' do
+      res = execute_service
+
+      expect(res).to be_success
+      expect(res.status).to eq(:updated)
+      expect(res.payload[:view]).to eq("public.#{relname}")
+      expect(res.payload[:rows_count]).to be_a(Integer) # estimated by default
+      expect(res.meta[:swap]).to be(true)
+      expect(res.meta[:steps]).to be_an(Array)
+      expect(res.meta[:steps].count).to eq(4)
+      # should include a CREATE MATERIALIZED VIEW ... WITH DATA and two RENAMEs
+      expect(res.meta[:steps].join(' ')).to include('CREATE MATERIALIZED VIEW')
+      expect(res.meta[:steps].join(' ')).to include('ALTER MATERIALIZED VIEW')
+      expect(res.meta[:steps].join(' ')).to include('WITH DATA')
+    end
+
+    describe 'exact row count' do
+      let(:row_count_strategy) { :exact }
+
+      it 'returns an exact COUNT(*)' do
+        res = execute_service
+        expect(res).to be_success
+        expect(res.payload[:rows_count]).to be_a(Integer)
+        expect(res.meta[:row_count_strategy]).to eq(:exact)
+      end
+    end
+
+    describe 'unknown row_count_strategy symbol' do
+      let(:row_count_strategy) { :bogus }
+
+      it 'still succeeds and includes rows_count: nil' do
+        res = execute_service
+        expect(res).to be_success
+        expect(res.payload).to include(rows_count: nil)
+        expect(res.meta[:row_count_strategy]).to eq(:bogus)
+      end
+    end
+
+    describe 'no row count requested (nil)' do
+      let(:row_count_strategy) { nil }
+
+      it 'omits rows_count' do
+        res = execute_service
+        expect(res).to be_success
+        expect(res.payload).not_to have_key(:rows_count)
+        expect(res.meta[:row_count_strategy]).to be_nil
+      end
+    end
+  end
+
+  describe 'recreating declared indexes' do
+    before do
+      create_mv!(relname, schema: 'public')
+      allow(conn).to receive(:schema_search_path).and_return('public')
+    end
+
+    it 'creates a unique index when unique_index_columns are provided' do
+      definition.unique_index_columns = %w[id]
+
+      pre_count = unique_index_count(relname)
+      res = execute_service
+      post_count = unique_index_count(relname)
+
+      expect(res).to be_success
+      expect(post_count).to be >= (pre_count + 1)
+    end
+
+    it 'supports multi-column unique indexes' do
+      definition.unique_index_columns = %w[id id]
+      res = execute_service
+      expect(res).to be_success
+      expect(unique_index_count(relname)).to be >= 1
+    end
+  end
+
+  describe 'schema_search_path resolution' do
+    before do
+      create_mv!(relname, schema: 'public')
+    end
+
+    it 'falls back to public when search_path is empty' do
+      allow(conn).to receive(:schema_search_path).and_return('')
+      res = execute_service
+      expect(res).to be_success
+      expect(res.payload[:view]).to eq("public.#{relname}")
+    end
+
+    it 'ignores non-existent schemas and falls back to public' do
+      allow(conn).to receive(:schema_search_path).and_return('other_schema')
+      res = execute_service
+      expect(res).to be_success
+      expect(res.payload[:view]).to eq("public.#{relname}")
+    end
+
+    it 'handles quoted tokens' do
+      allow(conn).to receive(:schema_search_path).and_return('"public"')
+      res = execute_service
+      expect(res).to be_success
+      expect(res.payload[:view]).to eq("public.#{relname}")
+    end
+
+    it 'handles $user token; uses public when user schema is absent' do
+      allow(conn).to receive(:schema_search_path).and_return('$user,public')
+      res = execute_service
+      expect(res).to be_success
+      expect(res.payload[:view]).to eq("public.#{relname}")
+    end
+  end
+
+  describe 'unexpected DB error' do
+    it 'wraps exception into error response with meta.steps and payload.view' do
+      create_mv!(relname, schema: 'public')
+      allow(conn).to receive(:schema_search_path).and_return('public')
+
+      # Force failure on the first CREATE to exercise rescue path
+      allow(ActiveRecord::Base).to receive(:connection).and_wrap_original do |orig, *args|
+        c = orig.call(*args)
+        allow(c).to receive(:execute)
+          .with(a_string_matching(/\ACREATE MATERIALIZED VIEW .* WITH DATA\z/))
+          .and_raise(StandardError, 'boom')
+        c
+      end
+
+      res = execute_service
+      expect(res.error?).to be(true)
+      expect(res.error).to match(/StandardError: boom/)
+      expect(res.payload[:view]).to eq("public.#{relname}")
+      expect(res.meta[:steps]).to be_an(Array)
+      expect(res.meta[:swap]).to be(true)
+    end
+  end
+end


### PR DESCRIPTION
Introduces a new `swap` refresh strategy for materialised views to enable near-zero downtime updates.

This strategy works by creating a new temporary view in the background. Once the new view is populated, it is atomically swapped with the original view inside a transaction. This process minimises the time the view is unavailable for queries.

The service also handles recreating any declared unique indexes on the new view after the swap.

closes #50 