### PR TITLE
feat: Adds rake task to validate MV performance

### DIFF
--- a/mat_views_demo/Gemfile
+++ b/mat_views_demo/Gemfile
@@ -3,6 +3,7 @@
 source 'https://rubygems.org'
 
 gem 'bootsnap', require: false
+gem 'csv'
 gem 'importmap-rails'
 gem 'jbuilder'
 gem 'kamal', require: false

--- a/mat_views_demo/Gemfile.lock
+++ b/mat_views_demo/Gemfile.lock
@@ -103,6 +103,7 @@ GEM
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
     crass (1.0.6)
+    csv (3.3.5)
     date (3.4.1)
     debug (1.11.0)
       irb (~> 1.10)
@@ -373,6 +374,7 @@ DEPENDENCIES
   bootsnap
   brakeman
   capybara
+  csv
   debug
   faker
   importmap-rails

--- a/mat_views_demo/lib/mat_views_demo/validator.rb
+++ b/mat_views_demo/lib/mat_views_demo/validator.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'csv'
+
+module MatViewsDemo
+  # Benchmarks regular (baseline) SQL vs reading from the MV.
+  class Validator
+    attr_reader :definition, :iterations, :connection
+
+    def initialize(definition, iterations: 5, connection: ActiveRecord::Base.connection)
+      @definition = definition
+      @iterations = Integer(iterations || 5)
+      @iterations = 1 if @iterations < 1
+      @connection = connection
+    end
+
+    # Returns a Hash with timing arrays and simple stats
+    # {
+    #   view: "mv_user_activity",
+    #   iterations: 5,
+    #   baseline_ms: [..], baseline_avg_ms: 12, baseline_min_ms: 10, baseline_max_ms: 15,
+    #   mv_ms: [..],       mv_avg_ms: 3,  mv_min_ms: 2,  mv_max_ms: 4,
+    #   speedup_avg: 4.0,
+    #   rows_baseline: 1234,
+    #   rows_mv: 1234
+    # }
+    def run
+      baseline_times = []
+      mv_times       = []
+      rows_baseline  = nil
+      rows_mv        = nil
+
+      iterations.times do
+        baseline_times << time_ms { rows_baseline = baseline_count }
+        mv_times       << time_ms { rows_mv       = mv_count }
+      end
+
+      {
+        view: definition.name,
+        iterations: iterations,
+        baseline_ms: baseline_times,
+        baseline_avg_ms: avg(baseline_times),
+        baseline_min_ms: baseline_times.min,
+        baseline_max_ms: baseline_times.max,
+        mv_ms: mv_times,
+        mv_avg_ms: avg(mv_times),
+        mv_min_ms: mv_times.min,
+        mv_max_ms: mv_times.max,
+        speedup_avg: speedup(avg(baseline_times), avg(mv_times)),
+        rows_baseline: rows_baseline,
+        rows_mv: rows_mv
+      }
+    end
+
+    private
+
+    def baseline_count
+      sql = "SELECT COUNT(*) FROM (#{definition.sql}) AS subq"
+      connection.select_value(sql).to_i
+    end
+
+    def mv_count
+      rel = %("#{definition.name}")
+      connection.select_value("SELECT COUNT(*) FROM #{rel}").to_i
+    end
+
+    def time_ms
+      t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      yield
+      ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - t0) * 1000).round
+    end
+
+    def avg(arr)
+      return 0 if arr.empty?
+
+      (arr.sum.to_f / arr.size).round
+    end
+
+    def speedup(baseline_avg, mv_avg)
+      return 0.0 if mv_avg.to_f <= 0.0
+
+      (baseline_avg.to_f / mv_avg).round(2)
+    end
+  end
+end

--- a/mat_views_demo/lib/tasks/mat_views_validate_demo.rake
+++ b/mat_views_demo/lib/tasks/mat_views_validate_demo.rake
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'rake'
+require 'csv'
+require 'fileutils'
+
+# Validate MV performance vs baseline SQL and write a CSV report.
+# Usage:
+#   bundle exec rake mat_views:validate_demo[iterations]
+# Examples:
+#   bundle exec rake mat_views:validate_demo[5]
+#   bundle exec rake mat_views:validate_demo            # defaults to 5
+namespace :mat_views do
+  desc 'Benchmark baseline vs MV and write CSV (mat_views:validate_demo[iterations])'
+  task :validate_demo, [:iterations] => :environment do |_t, args|
+    iterations = (args[:iterations] || ENV['ITER'] || 5).to_i
+    iterations = 1 if iterations < 1
+
+    conn = ActiveRecord::Base.connection
+
+    # Discover all materialized views present in the DB (exclude system schemas)
+    rows = conn.select_all(<<~SQL.squish)
+      SELECT schemaname, matviewname
+      FROM pg_matviews
+      WHERE schemaname NOT IN ('pg_catalog', 'information_schema')
+      ORDER BY schemaname, matviewname
+    SQL
+
+    mv_names = rows.rows.map { |(_, name)| name }.uniq
+    if mv_names.empty?
+      Rails.logger.info('[validate_demo] No materialized views found in the database. Nothing to validate.')
+      next
+    end
+
+    # Fetch definitions that match actual MV names (needed to get baseline SQL)
+    definitions = MatViews::MatViewDefinition.where(name: mv_names).order(:name).to_a
+    if definitions.empty?
+      Rails.logger.info('[validate_demo] Found MVs in DB, but no matching MatViewDefinition records. Nothing to validate.')
+      next
+    end
+
+    # Report location
+    ts_dir = File.join('tmp', 'mv_validate', Time.now.utc.strftime('%Y%m%d%H%M%S'))
+    FileUtils.mkdir_p(ts_dir)
+    out_csv = File.join(ts_dir, 'report.csv')
+
+    headers = %w[
+      view
+      iterations
+      baseline_avg_ms baseline_min_ms baseline_max_ms
+      mv_avg_ms mv_min_ms mv_max_ms
+      speedup_avg
+      rows_baseline rows_mv
+    ]
+
+    Rails.logger.info("[validate_demo] Validating #{definitions.size} view(s), iterations=#{iterations}")
+    CSV.open(out_csv, 'w') do |csv|
+      csv << headers
+
+      definitions.each do |defn|
+        unless mv_names.include?(defn.name)
+          Rails.logger.warn(%([validate_demo] Skipping "#{defn.name}" — not present in pg_matviews))
+          next
+        end
+
+        begin
+          result = MatViewsDemo::Validator.new(defn, iterations: iterations).run
+
+          csv << [
+            result[:view],
+            result[:iterations],
+            result[:baseline_avg_ms], result[:baseline_min_ms], result[:baseline_max_ms],
+            result[:mv_avg_ms],       result[:mv_min_ms],       result[:mv_max_ms],
+            result[:speedup_avg],
+            result[:rows_baseline], result[:rows_mv]
+          ]
+
+          Rails.logger.info(
+            "[validate_demo] #{result[:view]}: baseline_avg=#{result[:baseline_avg_ms]}ms, " \
+            "mv_avg=#{result[:mv_avg_ms]}ms, speedup≈#{result[:speedup_avg]}x"
+          )
+        rescue StandardError => e
+          Rails.logger.error(%([validate_demo] Error validating "#{defn.name}": #{e.class}: #{e.message}))
+        end
+      end
+    end
+
+    Rails.logger.info("[validate_demo] CSV written: #{out_csv}")
+  end
+end


### PR DESCRIPTION
Introduces a validator class and a corresponding Rake task to benchmark the performance of materialised views.

The `mat_views:validate_demo` task compares the query execution time of a materialised view against its underlying baseline SQL. It runs multiple iterations to gather statistics, calculates the average speedup, and verifies row counts.

A detailed CSV report is generated in the `tmp/mv_validate` directory, providing timing and speedup metrics for each view.

closes #12 